### PR TITLE
Update 2013-02-21-remove-trailing-slashes-in-your-rails-app.markdown

### DIFF
--- a/_posts/2013-02-21-remove-trailing-slashes-in-your-rails-app.markdown
+++ b/_posts/2013-02-21-remove-trailing-slashes-in-your-rails-app.markdown
@@ -21,7 +21,7 @@ gem 'rack-rewrite'
 
 # config/application.rb
 config.middleware.insert_before(Rack::Lock, Rack::Rewrite) do
-  r301 %r{^/(.*)/$}, '/$1'
+  r301 %r{^/+(.*)/$}, '/$1'
 end
 ```
 


### PR DESCRIPTION
Without `/+` a URL like http://domain.com//otherdomain.com/evil-do.php/ will 301 redirect to http://otherdomain.com/evil-do.php
That's a security risk https://dzone.com/articles/what-is-an-open-redirection-vulnerability-and-how